### PR TITLE
Upgrade nodejs to version 8.9 and add logger.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 cache:
   apt: true

--- a/deploy/playbook-single.yml
+++ b/deploy/playbook-single.yml
@@ -145,6 +145,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/load_balancer:/etc/load_balancer"
           - "./keys/gitlab/load_balancer:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -167,6 +168,7 @@
           - "../main_server:/main_server"
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/main_server:/etc/main_server"
+          - "../util:/util"
 
 - hosts: executionnode1
   become: yes
@@ -219,6 +221,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_1:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_1:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -268,6 +271,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_2:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_2:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -317,6 +321,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_3:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_3:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -366,6 +371,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_4:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_4:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -415,5 +421,6 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_5:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_5:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"

--- a/deploy/playbook.yml
+++ b/deploy/playbook.yml
@@ -145,6 +145,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/load_balancer:/etc/load_balancer"
           - "./keys/gitlab/load_balancer:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -167,6 +168,7 @@
           - "../main_server:/main_server"
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/main_server:/etc/main_server"
+          - "../util:/util"
 
 - hosts: executionnode1
   become: yes
@@ -230,6 +232,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_1:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_1:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -291,6 +294,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_2:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_2:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -351,6 +355,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_3:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_3:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -412,6 +417,7 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_4:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_4:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"
 
@@ -473,5 +479,6 @@
           - "/etc/localtime:/etc/localtime:ro"
           - "./configs/execution_nodes/execution_node_5:/etc/execution_node"
           - "./keys/gitlab/execution_nodes/execution_node_5:/root/.ssh/"
+          - "../util:/util"
         env:
           GITLAB_IP: "{{ gitlab_hostname }}"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -75,6 +75,8 @@ mkdir -p "$INSTALL_DIR"/execution_nodes/execution_node_5
 cp -rf ../execution_nodes/* "$INSTALL_DIR"/execution_nodes/execution_node_5
 npm install --prefix "$INSTALL_DIR"/execution_nodes/execution_node_5
 
+cp -rf ../util "$INSTALL_DIR"/
+npm install --prefix "$INSTALL_DIR"/util
 cp -rf ../deploy "$INSTALL_DIR"/
 
 echo "Creating SSL certificates"
@@ -83,5 +85,5 @@ bash keys.sh
 
 cat << EOF
 Done installing base packages.
-Follow the remaining procedure to finish installing AutolabJS. 
+Follow the remaining procedure to finish installing AutolabJS.
 EOF

--- a/execution_nodes/Dockerfile
+++ b/execution_nodes/Dockerfile
@@ -14,12 +14,16 @@ ENV LC_ALL en_IN.UTF-8
 # verify modified configuration
 RUN dpkg-reconfigure --frontend noninteractive locales
 
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
 RUN apt-get update && apt-get install -y software-properties-common && \
   apt-add-repository -y ppa:webupd8team/java && apt-get update && \
   echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | \
    debconf-set-selections && apt-get install -y --force-yes oracle-java8-installer \
-  nodejs npm git && add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+  nodejs build-essential git && add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
   apt-get update && apt-get install -y gcc-6 g++-6
+RUN rm nodesource_setup.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/load_balancer/Dockerfile
+++ b/load_balancer/Dockerfile
@@ -14,7 +14,11 @@ ENV LC_ALL en_IN.UTF-8
 # verify modified configuration
 RUN dpkg-reconfigure --frontend noninteractive locales
 
-RUN apt-get update && apt-get install --force-yes -y nodejs npm git
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get update && apt-get install --force-yes -y nodejs build-essential git
+RUN rm nodesource_setup.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/main_server/Dockerfile
+++ b/main_server/Dockerfile
@@ -14,7 +14,11 @@ ENV LC_ALL en_IN.UTF-8
 # verify modified configuration
 RUN dpkg-reconfigure --frontend noninteractive locales
 
-RUN apt-get update && apt-get install --force-yes -y nodejs nodejs-legacy npm git
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get update && apt-get install --force-yes -y nodejs build-essential git
+RUN rm nodesource_setup.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -20,7 +20,7 @@ echo -e "USE mysql;\nUPDATE user SET password=PASSWORD('root') WHERE user='root'
 npm --quiet install --prefix main_server 1>/dev/null
 npm --quiet install --prefix main_server/public/js 1>/dev/null
 npm --quiet install --prefix load_balancer 1>/dev/null
-
+npm --quiet install --prefix util 1>/dev/null
 mv execution_nodes/ execution_nodes_data/
 # The current test runs for 5 execution nodes
 for ((i=1; i <= 5; i++))

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -86,25 +86,25 @@ sleep 2
 # show the dependency status for all the components
 echo -e "\n\n=====Main Server Dependency Status====="
 cd ../../main_server
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 
 echo -e "\n\n=====Load Balancer Dependency Status====="
 cd ../load_balancer
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 
 #dependency check for execution nodes limited to one check. since all execution
 #nodes share the same initial files
 echo -e "\n\n=====Execution Nodes Dependency Status====="
 cd ../execution_nodes/execution_node_1
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 cd ../
 
 echo -e "\n\n=====Functional Tests Dependency Status====="
 cd ../tests/functional_tests
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 
 

--- a/util/logger.js
+++ b/util/logger.js
@@ -1,0 +1,30 @@
+const winston = require('winston');
+const fs = require('fs');
+
+const logDir = 'log';
+const timeStampFormat = () => (new Date()).toLocaleTimeString();
+
+// Create the log directory if it does not exist
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir);
+}
+
+const logger = new (winston.Logger)({
+  transports: [
+    // colorize the output to the console
+    new (winston.transports.Console)({
+      timestamp: timeStampFormat,
+      colorize: true,
+      level: 'info',
+    }),
+    new (winston.transports.File)({
+      filename: `${logDir}/componentLog.txt`,
+      timestamp: timeStampFormat,
+      level: 'debug',
+    }),
+  ],
+});
+
+logger.debug('===============Information logging started===============');
+
+module.exports = logger;

--- a/util/package.json
+++ b/util/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "logger",
+  "version": "0.1.0",
+  "description": "logger for all components of AutolabJS",
+  "main": "logger.js",
+  "scripts": {
+    "start": "node logger.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AutolabJS/AutolabJS.git"
+  },
+  "keywords": [
+    "autolab",
+    "lab",
+    "evaluation",
+    "logger"
+  ],
+  "author": "Ankshit Jain",
+  "license": "GPL-2.0",
+  "bugs": {
+    "url": "https://github.com/AutolabJS/AutolabJS/issues"
+  },
+  "homepage": "https://github.com/AutolabJS/AutolabJS/wiki",
+  "dependencies": {
+    "winston": "^2.4.0"
+  }
+}


### PR DESCRIPTION
This commit deals with upgrading nodejs in the dockers to version 8.9 from nodejs 4.5.1. The version of nodejs on travis is upgraded from nodejs 6 to nodejs 8, which uses the latest release, i.e. nodejs 8.9.
The `npm outdated` results in exit status 1 in the newer version and hence the failure has to be bypassed.
A separate module for logging is included at `util/logger.js`, which uses winston logger.
All the containers mount this path and can use the logger.js for logging when updated in future.