### PR TITLE
Upgrade nodejs to version 8.9 in all components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 cache:
   apt: true

--- a/execution_nodes/Dockerfile
+++ b/execution_nodes/Dockerfile
@@ -14,12 +14,16 @@ ENV LC_ALL en_IN.UTF-8
 # verify modified configuration
 RUN dpkg-reconfigure --frontend noninteractive locales
 
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
 RUN apt-get update && apt-get install -y software-properties-common && \
   apt-add-repository -y ppa:webupd8team/java && apt-get update && \
   echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | \
    debconf-set-selections && apt-get install -y --force-yes oracle-java8-installer \
-  nodejs npm git && add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+  nodejs build-essential git && add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
   apt-get update && apt-get install -y gcc-6 g++-6
+RUN rm nodesource_setup.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/load_balancer/Dockerfile
+++ b/load_balancer/Dockerfile
@@ -14,7 +14,11 @@ ENV LC_ALL en_IN.UTF-8
 # verify modified configuration
 RUN dpkg-reconfigure --frontend noninteractive locales
 
-RUN apt-get update && apt-get install --force-yes -y nodejs npm git
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get update && apt-get install --force-yes -y nodejs build-essential git
+RUN rm nodesource_setup.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/main_server/Dockerfile
+++ b/main_server/Dockerfile
@@ -14,7 +14,11 @@ ENV LC_ALL en_IN.UTF-8
 # verify modified configuration
 RUN dpkg-reconfigure --frontend noninteractive locales
 
-RUN apt-get update && apt-get install --force-yes -y nodejs nodejs-legacy npm git
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get update && apt-get install --force-yes -y nodejs build-essential git
+RUN rm nodesource_setup.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -86,25 +86,25 @@ sleep 2
 # show the dependency status for all the components
 echo -e "\n\n=====Main Server Dependency Status====="
 cd ../../main_server
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 
 echo -e "\n\n=====Load Balancer Dependency Status====="
 cd ../load_balancer
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 
 #dependency check for execution nodes limited to one check. since all execution
 #nodes share the same initial files
 echo -e "\n\n=====Execution Nodes Dependency Status====="
 cd ../execution_nodes/execution_node_1
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 cd ../
 
 echo -e "\n\n=====Functional Tests Dependency Status====="
 cd ../tests/functional_tests
-npm outdated
+npm outdated || :
 npm-check || :    #bypass failure of npm-check
 
 


### PR DESCRIPTION
This PR deals with upgrading nodejs in the dockers to version 8.9 from nodejs 4.5.1. The version of nodejs on travis is upgraded from nodejs 6 to nodejs 8, which uses the latest release, i.e. nodejs 8.9.
The `npm outdated` results in exit status 1 in the newer version and hence the failure has to be bypassed.